### PR TITLE
Update to 24.08, libsecret included in Electron2.BaseApp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -1,10 +1,10 @@
 id: io.anytype.anytype
 base: org.electronjs.Electron2.BaseApp
-base-version: "23.08"
+base-version: "24.08"
 rename-desktop-file: anytype.desktop
 rename-icon: anytype
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 separate-locales: false
 command: anytype
@@ -16,7 +16,6 @@ finish-args:
   - --socket=x11
   - --talk-name=org.freedesktop.secrets
 modules:
-  - shared-modules/libsecret/libsecret.json
   - name: anytype
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Update to 24.08
Also see https://github.com/flathub/org.electronjs.Electron2.BaseApp/commit/cfb39a752f06e5c5a71c7a58141a199cc5568405