### PR TITLE
Update Anytype to v0.43.8

### DIFF
--- a/io.anytype.anytype.metainfo.xml
+++ b/io.anytype.anytype.metainfo.xml
@@ -25,6 +25,7 @@
   <launchable type="desktop-id">io.anytype.anytype.desktop</launchable>
 
   <releases>
+    <release version="0.43.8" date="2024-11-26" />
     <release version="0.43.7" date="2024-11-22" />
     <release version="0.43.6" date="2024-11-11" />
     <release version="0.43.4" date="2024-10-31" />

--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -35,8 +35,8 @@ modules:
         dest-filename: anytype_amd64.deb
         only-arches:
           - x86_64
-        sha256: b7d2c2aab50dd01cab674d106db031972b4d6ec88ef3646800bd256a88b9f916
-        url: https://github.com/anyproto/anytype-ts/releases/download/v0.43.7/anytype_0.43.7_amd64.deb
+        sha256: 79a25f8d6431bcb62c0a61d665a8f882143a5f0946585c926e6bf1648707d073
+        url: https://github.com/anyproto/anytype-ts/releases/download/v0.43.8/anytype_0.43.8_amd64.deb
       - type: file
         path: io.anytype.anytype.metainfo.xml
       - type: script


### PR DESCRIPTION
This PR updates Anytype to 0.43.8.

Up until Anytype has an option to disable automatic checking for updates, we will have to update for all the minor versions and patches in order to not have to dismiss the update popup all the time. It might be worth investigating whether we can somehow disable the automatic update check on our side.