### PR TITLE
Update Anytype to 0.44.0

### DIFF
--- a/io.anytype.anytype.metainfo.xml
+++ b/io.anytype.anytype.metainfo.xml
@@ -25,6 +25,7 @@
   <launchable type="desktop-id">io.anytype.anytype.desktop</launchable>
 
   <releases>
+    <release version="0.44.0" date="2024-12-18" />
     <release version="0.43.8" date="2024-11-26" />
     <release version="0.43.7" date="2024-11-22" />
     <release version="0.43.6" date="2024-11-11" />

--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -35,8 +35,8 @@ modules:
         dest-filename: anytype_amd64.deb
         only-arches:
           - x86_64
-        sha256: 79a25f8d6431bcb62c0a61d665a8f882143a5f0946585c926e6bf1648707d073
-        url: https://github.com/anyproto/anytype-ts/releases/download/v0.43.8/anytype_0.43.8_amd64.deb
+        sha256: e0186794b5d0ab9b7db43734d1fe71232601b8e18455a1fa39625ee2cddf5e36
+        url: https://github.com/anyproto/anytype-ts/releases/download/v0.44.0/anytype_0.44.0_amd64.deb
       - type: file
         path: io.anytype.anytype.metainfo.xml
       - type: script


### PR DESCRIPTION
This PR updates Anytype to 0.44.0.

The cursor scaling issue (small cursor) on Wayland with fractional scaling on HiDPI monitors seems to be back again, at least for me, and even the temporary workaround for Flatpak applications (see the related issue https://github.com/electron/electron/issues/19810) does not work this time. After some initial fiddling, I could not fix the issue. We can try to fix the cursor scaling issue before merging.