### PR TITLE
chore: Update to 0.45.3

### DIFF
--- a/io.anytype.anytype.metainfo.xml
+++ b/io.anytype.anytype.metainfo.xml
@@ -25,6 +25,7 @@
   <launchable type="desktop-id">io.anytype.anytype.desktop</launchable>
 
   <releases>
+    <release version="0.45.3" date="2025-02-17" />
     <release version="0.45.2" date="2025-02-13" />
     <release version="0.45.1" date="2025-02-12" />
     <release version="0.44.0" date="2024-12-18" />

--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -35,8 +35,8 @@ modules:
         dest-filename: anytype_amd64.deb
         only-arches:
           - x86_64
-        sha256: 81cf9a405424c4b282538f5a858c0095bea80652bbd7755c1c0e2a6203482761
-        url: https://github.com/anyproto/anytype-ts/releases/download/v0.45.2/anytype_0.45.2_amd64.deb
+        sha256: f5d39b2205a797df6c207aa595e5b87cd60b09ba90e6249221245191605323bd
+        url: https://github.com/anyproto/anytype-ts/releases/download/v0.45.3/anytype_0.45.3_amd64.deb
       - type: file
         path: io.anytype.anytype.metainfo.xml
       - type: script


### PR DESCRIPTION
This pull request updates Anytype to version 0.45.3 with a few supplementary fixes following the initial hotfixes to this new major release.