### PR TITLE
Enable Native Wayland Support by Default

### DIFF
--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -13,12 +13,14 @@ finish-args:
   - --share=network
   - --share=ipc
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   # required for system tray
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.secrets
   # required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 modules:
   - name: anytype
     buildsystem: simple


### PR DESCRIPTION
I personally think this is a worthwhile change, as this is what most apps do by now. Native Wayland support is pretty robust in recent Electron versions (which this app uses), and the benefits far outweigh the negatives, IMHO.