### PR TITLE
Update Anytype to 0.46.0

### DIFF
--- a/io.anytype.anytype.metainfo.xml
+++ b/io.anytype.anytype.metainfo.xml
@@ -25,6 +25,11 @@
   <launchable type="desktop-id">io.anytype.anytype.desktop</launchable>
 
   <releases>
+    <release version="0.46.0" date="2025-04-16">
+      <description>
+        <p>Create a manual backup before updating. This release replaces the underlying database, and Anytype must perform a data migration to the new database format upon running the new release for the first time.</p>
+      </description>
+    </release>
     <release version="0.45.3" date="2025-02-17" />
     <release version="0.45.2" date="2025-02-13" />
     <release version="0.45.1" date="2025-02-12" />

--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -37,8 +37,8 @@ modules:
         dest-filename: anytype_amd64.deb
         only-arches:
           - x86_64
-        sha256: f5d39b2205a797df6c207aa595e5b87cd60b09ba90e6249221245191605323bd
-        url: https://github.com/anyproto/anytype-ts/releases/download/v0.45.3/anytype_0.45.3_amd64.deb
+        sha256: c2cf8ecf61645a5e489814449994eee1f6eb1b6e521b6895b1afc6fe7ec3b0c7
+        url: https://github.com/anyproto/anytype-ts/releases/download/v0.46.0/anytype_0.46.0_amd64.deb
       - type: file
         path: io.anytype.anytype.metainfo.xml
       - type: script


### PR DESCRIPTION
This PR updates Anytype to 0.46.0. This is a large release which replaces the underlying database with a new one, and migration must be performed (from within the app itself). A manual backup before updating is recommended.

Furthermore, the application requests access to system bus, which I really do not want to give. We need to test whether it is necessary for the migration to succeed.
```
[2:0417/092114.860047:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
```