### PR TITLE
chore: Update to 0.46.3

### DIFF
--- a/io.anytype.anytype.metainfo.xml
+++ b/io.anytype.anytype.metainfo.xml
@@ -25,6 +25,7 @@
   <launchable type="desktop-id">io.anytype.anytype.desktop</launchable>
 
   <releases>
+    <release version="0.46.3" date="2025-04-23" />
     <release version="0.46.2" date="2025-04-23" />
     <release version="0.46.1" date="2025-04-18" />
     <release version="0.46.0" date="2025-04-16">

--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -37,8 +37,8 @@ modules:
         dest-filename: anytype_amd64.deb
         only-arches:
           - x86_64
-        sha256: 4741e77969013132228e84e3d9d3bf97c201773cc7fb54968fe143228abd66b5
-        url: https://github.com/anyproto/anytype-ts/releases/download/v0.46.2/anytype_0.46.2_amd64.deb
+        sha256: e226a41ca539155afb9e3fdc77e45a3bcc0ba6553568d3b67cee4aefeb89aa53
+        url: https://github.com/anyproto/anytype-ts/releases/download/v0.46.3/anytype_0.46.3_amd64.deb
       - type: file
         path: io.anytype.anytype.metainfo.xml
       - type: script


### PR DESCRIPTION
This PR updates Anytype to 0.46.3, another bug fix release.