### PR TITLE
chore: Update to 0.46.8

### DIFF
--- a/io.anytype.anytype.metainfo.xml
+++ b/io.anytype.anytype.metainfo.xml
@@ -25,6 +25,7 @@
   <launchable type="desktop-id">io.anytype.anytype.desktop</launchable>
 
   <releases>
+    <release version="0.46.8" date="2025-05-27" />
     <release version="0.46.7" date="2025-05-26" />
     <release version="0.46.5" date="2025-05-09" />
     <release version="0.46.4" date="2025-04-24" />

--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -37,8 +37,8 @@ modules:
         dest-filename: anytype_amd64.deb
         only-arches:
           - x86_64
-        sha256: 37b817fc2f14a1c173fc65f6272d49354dda5e85794f6be54e60c1be434fd483
-        url: https://github.com/anyproto/anytype-ts/releases/download/v0.46.7/anytype_0.46.7_amd64.deb
+        sha256: 91e21390082c3f0cbebc0105966838334fddff4e75eef85e1a51181b5493b2d5
+        url: https://github.com/anyproto/anytype-ts/releases/download/v0.46.8/anytype_0.46.8_amd64.deb
       - type: file
         path: io.anytype.anytype.metainfo.xml
       - type: script


### PR DESCRIPTION
This PR update Anytype to 0.46.8, another bug fix release.