### PR TITLE
chore: Update to 0.47.3

### DIFF
--- a/io.anytype.anytype.metainfo.xml
+++ b/io.anytype.anytype.metainfo.xml
@@ -25,6 +25,7 @@
   <launchable type="desktop-id">io.anytype.anytype.desktop</launchable>
 
   <releases>
+    <release version="0.47.3" date="2025-06-18" />
     <release version="0.46.8" date="2025-05-27" />
     <release version="0.46.7" date="2025-05-26" />
     <release version="0.46.5" date="2025-05-09" />

--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -37,8 +37,8 @@ modules:
         dest-filename: anytype_amd64.deb
         only-arches:
           - x86_64
-        sha256: 91e21390082c3f0cbebc0105966838334fddff4e75eef85e1a51181b5493b2d5
-        url: https://github.com/anyproto/anytype-ts/releases/download/v0.46.8/anytype_0.46.8_amd64.deb
+        sha256: 232ad3979b8fc54a0c3bcd88a2baf196b106cf19371a8b4955b853b921ab25b9
+        url: https://github.com/anyproto/anytype-ts/releases/download/v0.47.3/anytype_0.47.3_amd64.deb
         x-checker-data:
           type: anitya
           project-id: 378448


### PR DESCRIPTION
The auto-update CI action does not seem to work. Updating manually in the meantime. 