### PR TITLE
Fix x-data-checker

### DIFF
--- a/io.anytype.anytype.yml
+++ b/io.anytype.anytype.yml
@@ -43,7 +43,7 @@ modules:
           type: anitya
           project-id: 378448
           stable-only: true
-          url-template: https://github.com/anyproto/anytype-ts/releases/download/v$version/anytype_$version_amd64.deb
+          url-template: https://github.com/anyproto/anytype-ts/releases/download/v${version}/anytype_${version}_amd64.deb
       - type: file
         path: io.anytype.anytype.metainfo.xml
       - type: script


### PR DESCRIPTION
`$version_amd64` was substituted instead of `$version`, leading to the following error:
```
INFO    src.manifest: Started check [1/1] file anytype/anytype_amd64.deb (from io.anytype.anytype.yml)
ERROR   src.manifest: Failed to check file anytype/anytype_amd64.deb with AnityaChecker: Error substituting template: 'version_amd64'
```
Using braces for the substition(`${version}` instead of `$version`) seems to correctly resolve:
```
INFO    src.manifest: Checking 1 external data items
INFO    src.manifest: Started check [1/1] file anytype/anytype_amd64.deb (from io.anytype.anytype.yml)
INFO    src.manifest: Finished check [1/1] file anytype/anytype_amd64.deb (from io.anytype.anytype.yml)
INFO    src.main: Check finished with 0 error(s)
```